### PR TITLE
JUnit Reporter Enhancements

### DIFF
--- a/Source/CDRJUnitXMLReporter.m
+++ b/Source/CDRJUnitXMLReporter.m
@@ -57,7 +57,7 @@
             break;
         case CDRExampleStateSkipped:
             if (self.skippedAsFailed) {
-                [failureMessages_ addObject:[NSString stringWithFormat:@"%@\n%@\n",[example fullText], @"Skipped"]];
+                [failureMessages_ addObject:[NSString stringWithFormat:@"%@\n%@\n",[example fullText], @"Test skipped and we hate it. Fail!"]];
             } else {
                 [skippedMessages_ addObject:example.fullText];
             }
@@ -74,19 +74,22 @@
 - (void)appendXMLForTestcaseWithName:(NSString *)name body:(NSString *)body toString:(NSMutableString *)xml {
     NSUInteger firstWordEndIndex = [name rangeOfCharacterFromSet:[NSCharacterSet whitespaceCharacterSet]].location;
     if (firstWordEndIndex != NSNotFound) {
-        [xml appendFormat:@"\t<testcase classname=\"%@\" name=\"%@\">\n", [name substringToIndex:firstWordEndIndex], [self escape:name]];
+        [xml appendFormat:@"\t<testcase classname=\"%@\" name=\"%@\"", [name substringToIndex:firstWordEndIndex], [self escape:name]];
     } else {
-        [xml appendFormat:@"\t<testcase name=\"%@\">\n", [self escape:name]];
+        [xml appendFormat:@"\t<testcase name=\"%@\"", [self escape:name]];
     }
     
     if (body) {
+        [xml appendString:@">\n"];
         [xml appendFormat:@"\t\t%@\n", body];
+        [xml appendString:@"\t</testcase>\n"];
+    } else {
+        [xml appendString:@"/>\n"];
     }
-    [xml appendString:@"\t</testcase>\n"];
 }
 
 - (void)runDidComplete {
-    NSTimeInterval time = [startTime_ timeIntervalSinceNow] * (-1);
+    NSTimeInterval time = fabs([startTime_ timeIntervalSinceNow]);
     
     NSMutableString *xml = [NSMutableString string];
     [xml appendString:@"<?xml version=\"1.0\"?>\n"];

--- a/Source/CDRJUnitXMLReporter.m
+++ b/Source/CDRJUnitXMLReporter.m
@@ -7,6 +7,10 @@
 - (id)init {
     if (self = [super init]) {
         successMessages_ = [[NSMutableArray alloc] init];
+        
+        if (getenv("CEDAR_JUNIT_XML_SKIPPED_AS_FAILED")) {
+            self.skippedAsFailed = YES;
+        }
     }
     return self;
 }
@@ -52,7 +56,11 @@
             [successMessages_ addObject:example.fullText];
             break;
         case CDRExampleStateSkipped:
-            [skippedMessages_ addObject:example.fullText];
+            if (self.skippedAsFailed) {
+                [failureMessages_ addObject:[NSString stringWithFormat:@"%@\n%@\n",[example fullText], @"Skipped"]];
+            } else {
+                [skippedMessages_ addObject:example.fullText];
+            }
             break;
         case CDRExampleStateFailed:
         case CDRExampleStateError:

--- a/Source/Headers/CDRJUnitXMLReporter.h
+++ b/Source/Headers/CDRJUnitXMLReporter.h
@@ -5,4 +5,6 @@
     NSMutableArray *successMessages_;
 }
 
+@property (nonatomic) BOOL skippedAsFailed;
+
 @end


### PR DESCRIPTION
Problem: we want Jenkins build to be marked as unstable when some specs are skipped.

I started with adding skipped tests to XML report. Unfortunately there is no easy way to configure Jenkins to mark build as unstable when some tests are skipped. Hence I had to add new cedar configuration variable CEDAR_JUNIT_XML_SKIPPED_AS_FAILED that makes skipped tests report as failed in Junit XML.
